### PR TITLE
Vercelデプロイエラー修正

### DIFF
--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -3,10 +3,10 @@ import { z } from "zod";
 // ログインフォーム
 export const loginSchema = z.object({
 	email: z
-		.string({ required_error: "メールアドレスは必須です" })
+		.string({ message: "メールアドレスは必須です" })
 		.email("正しいメールアドレスを入力してください"),
 	password: z
-		.string({ required_error: "パスワードは必須です" })
+		.string({ message: "パスワードは必須です" })
 		.min(6, "パスワードは6文字以上で入力してください"),
 });
 
@@ -15,16 +15,16 @@ export type LoginSchema = z.infer<typeof loginSchema>;
 // 商品登録・編集
 export const productSchema = z.object({
 	name: z
-		.string({ required_error: "商品名は必須です" })
+		.string({ message: "商品名は必須です" })
 		.min(1, "商品名は必須です"),
 	categoryId: z
-		.string({ required_error: "カテゴリを選択してください" })
+		.string({ message: "カテゴリを選択してください" })
 		.uuid("カテゴリを選択してください"),
 	price: z
-		.number({ required_error: "価格を入力してください" })
+		.number({ message: "価格を入力してください" })
 		.min(0, "価格は0以上で入力してください"),
 	minStockThreshold: z
-		.number({ required_error: "在庫下限値を入力してください" })
+		.number({ message: "在庫下限値を入力してください" })
 		.min(0, "在庫下限値は0以上で入力してください"),
 	description: z.string().optional(),
 });
@@ -34,13 +34,13 @@ export type ProductSchema = z.infer<typeof productSchema>;
 // 入出庫記録
 export const inventoryTransactionSchema = z.object({
 	productId: z
-		.string({ required_error: "商品を選択してください" })
+		.string({ message: "商品を選択してください" })
 		.uuid("商品を選択してください"),
 	transactionType: z.enum(["IN", "OUT"], {
-		required_error: "入出庫種別を選択してください",
+		message: "入出庫種別を選択してください",
 	}),
 	quantity: z
-		.number({ required_error: "数量を入力してください" })
+		.number({ message: "数量を入力してください" })
 		.min(1, "数量は1以上で入力してください"),
 	notes: z.string().optional(),
 });


### PR DESCRIPTION
## 概要
VercelでのNext.jsビルドエラーを修正しました。

## 問題
Vercelデプロイ時に以下のエラーが発生：
```
Type error: No overload matches this call.
'required_error' does not exist in type '{ error?: string | ... }'
```

## 修正内容
- **Zod v4互換性対応**: `required_error` → `message` に変更
- 対象ファイル: `src/lib/validations.ts`
- 修正箇所: loginSchema, productSchema, inventoryTransactionSchema

## 修正前後の比較
```typescript
// 修正前 (Zod v3 形式)
.string({ required_error: "メールアドレスは必須です" })

// 修正後 (Zod v4 形式)  
.string({ message: "メールアドレスは必須です" })
```

## 検証結果
- ✅ ローカルビルド成功確認済み
- ✅ 型エラー解消
- ✅ 機能動作に影響なし

## 環境変数設定が必要
Vercelダッシュボードで以下の環境変数設定が必要：
- `NEXTAUTH_SECRET`
- `NEXTAUTH_URL` (本番URL)
- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`

🤖 Generated with [Claude Code](https://claude.ai/code)