### PR TITLE
feat: レスポンシブ対応とエラーハンドリング統一

### DIFF
--- a/src/components/dashboard/dashboard-content.tsx
+++ b/src/components/dashboard/dashboard-content.tsx
@@ -8,9 +8,11 @@ import {
 	Package, 
 	ShoppingCart, 
 	AlertTriangle, 
-	TrendingDown,
-	Loader2 
+	TrendingDown
 } from "lucide-react";
+import { LoadingDisplay } from "@/components/ui/loading-display";
+import { ErrorDisplay } from "@/components/ui/error-display";
+import { StatsGrid } from "@/components/ui/responsive-grid";
 
 interface DashboardData {
 	overview: {
@@ -83,25 +85,22 @@ export function DashboardContent() {
 	};
 
 	if (loading) {
-		return (
-			<div className="flex items-center justify-center h-64">
-				<Loader2 className="h-8 w-8 animate-spin text-slate-600" />
-			</div>
-		);
+		return <LoadingDisplay message="ダッシュボードデータを読み込み中..." />;
 	}
 
 	if (error || !data) {
 		return (
-			<div className="text-center py-8">
-				<p className="text-red-600">{error || "データがありません"}</p>
-			</div>
+			<ErrorDisplay
+				message={error || "ダッシュボードデータの取得に失敗しました"}
+				onRetry={fetchDashboardData}
+			/>
 		);
 	}
 
 	return (
 		<div className="space-y-6">
 			{/* 統計カード */}
-			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+			<StatsGrid>
 				<StatCard
 					title="総商品数"
 					value={data.overview.totalProducts}
@@ -130,7 +129,7 @@ export function DashboardContent() {
 					icon={AlertTriangle}
 					iconColor="text-amber-600"
 				/>
-			</div>
+			</StatsGrid>
 
 			{/* メインコンテンツエリア */}
 			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/components/inventory/inventory-content.tsx
+++ b/src/components/inventory/inventory-content.tsx
@@ -8,8 +8,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card } from "@/components/ui/card";
-import { Loader2, Search, Filter, RefreshCw } from "lucide-react";
+import { Search, Filter, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
+import { LoadingDisplay } from "@/components/ui/loading-display";
+import { NoInventoryState } from "@/components/ui/empty-state";
 
 interface Product {
 	id: string;
@@ -115,11 +117,7 @@ export function InventoryContent() {
 	});
 
 	if (loading) {
-		return (
-			<div className="flex items-center justify-center h-64">
-				<Loader2 className="h-8 w-8 animate-spin text-slate-600" />
-			</div>
-		);
+		return <LoadingDisplay message="入出庫データを読み込み中..." />;
 	}
 
 	return (
@@ -198,6 +196,7 @@ export function InventoryContent() {
 						<DataTable
 							columns={inventoryColumns}
 							data={filteredTransactions}
+							emptyStateComponent={<NoInventoryState />}
 						/>
 					</Card>
 				</div>

--- a/src/components/inventory/inventory-form.tsx
+++ b/src/components/inventory/inventory-form.tsx
@@ -11,7 +11,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card } from "@/components/ui/card";
 import { toast } from "sonner";
-import { Loader2, Package, Plus, Minus } from "lucide-react";
+import { Package, Plus, Minus } from "lucide-react";
+import { LoadingSpinner } from "@/components/ui/loading-display";
 
 interface Product {
 	id: string;
@@ -200,16 +201,11 @@ export function InventoryForm({ products, onSuccess }: InventoryFormProps) {
 					disabled={loading || !selectedProduct}
 					className="w-full"
 				>
-					{loading ? (
-						<>
-							<Loader2 className="h-4 w-4 mr-2 animate-spin" />
-							処理中...
-						</>
-					) : (
-						<>
-							{transactionType === "IN" ? "入庫" : "出庫"}処理を実行
-						</>
-					)}
+					{loading && <LoadingSpinner size="sm" className="mr-2" />}
+					{loading 
+						? "処理中..." 
+						: `${transactionType === "IN" ? "入庫" : "出庫"}処理を実行`
+					}
 				</Button>
 			</form>
 		</Card>

--- a/src/components/products/product-form.tsx
+++ b/src/components/products/product-form.tsx
@@ -24,6 +24,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { LoadingSpinner } from "@/components/ui/loading-display";
 import { type ProductSchema, productSchema } from "@/lib/validations";
 import type { Database } from "@/types/database";
 
@@ -230,6 +231,7 @@ export function ProductForm({
 								disabled={isSubmitting}
 								className="w-full md:w-auto"
 							>
+								{isSubmitting && <LoadingSpinner size="sm" className="mr-2" />}
 								{isSubmitting
 									? `${isEditing ? "更新" : "登録"}中...`
 									: `${isEditing ? "更新" : "登録"}する`}

--- a/src/components/products/product-list.tsx
+++ b/src/components/products/product-list.tsx
@@ -6,8 +6,12 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DataTable } from "@/components/ui/data-table";
+import { LoadingDisplay } from "@/components/ui/loading-display";
+import { ErrorDisplay } from "@/components/ui/error-display";
+import { NoProductsState } from "@/components/ui/empty-state";
 import { columns } from "./columns";
 import type { Database } from "@/types/database";
+import { useRouter } from "next/navigation";
 
 type Product = Database["public"]["Tables"]["products"]["Row"] & {
 	categories: {
@@ -17,6 +21,7 @@ type Product = Database["public"]["Tables"]["products"]["Row"] & {
 };
 
 export function ProductList() {
+	const router = useRouter();
 	const [products, setProducts] = useState<Product[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
@@ -45,30 +50,23 @@ export function ProductList() {
 	};
 
 	if (loading) {
-		return (
-			<Card>
-				<CardContent className="flex items-center justify-center h-64">
-					<div className="text-center">
-						<div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
-						<p className="text-muted-foreground">読み込み中...</p>
-					</div>
-				</CardContent>
-			</Card>
-		);
+		return <LoadingDisplay message="商品データを読み込み中..." />;
 	}
 
 	if (error) {
 		return (
-			<Card>
-				<CardContent className="flex items-center justify-center h-64">
-					<div className="text-center">
-						<p className="text-destructive mb-4">{error}</p>
-						<Button onClick={fetchProducts} variant="outline">
-							再試行
-						</Button>
-					</div>
-				</CardContent>
-			</Card>
+			<ErrorDisplay
+				message={error}
+				onRetry={fetchProducts}
+			/>
+		);
+	}
+
+	if (products.length === 0) {
+		return (
+			<NoProductsState 
+				onAddProduct={() => router.push('/products/new')}
+			/>
 		);
 	}
 

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -20,6 +20,8 @@ interface DataTableProps<TData, TValue> {
 	data: TData[];
 	searchKey?: string;
 	searchPlaceholder?: string;
+	emptyStateMessage?: string;
+	emptyStateComponent?: React.ReactNode;
 }
 
 export function DataTable<TData, TValue>({
@@ -27,6 +29,8 @@ export function DataTable<TData, TValue>({
 	data,
 	searchKey,
 	searchPlaceholder = "検索...",
+	emptyStateMessage = "データがありません",
+	emptyStateComponent,
 }: DataTableProps<TData, TValue>) {
 	const [sorting, setSorting] = useState<SortingState>([]);
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -97,11 +101,12 @@ export function DataTable<TData, TValue>({
 							))
 						) : (
 							<tr>
-								<td
-									colSpan={columns.length}
-									className="h-24 text-center text-muted-foreground"
-								>
-									データがありません
+								<td colSpan={columns.length} className="h-24 p-0">
+									{emptyStateComponent || (
+										<div className="text-center text-muted-foreground py-8">
+											{emptyStateMessage}
+										</div>
+									)}
 								</td>
 							</tr>
 						)}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Plus, Package, Search, FileX } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  icon?: "package" | "search" | "file" | "plus";
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  className?: string;
+  variant?: "card" | "page";
+}
+
+const iconMap = {
+  package: Package,
+  search: Search,
+  file: FileX,
+  plus: Plus
+};
+
+export function EmptyState({
+  icon = "package",
+  title,
+  description,
+  actionLabel,
+  onAction,
+  className,
+  variant = "card"
+}: EmptyStateProps) {
+  const IconComponent = iconMap[icon];
+
+  const content = (
+    <div className="text-center max-w-md mx-auto">
+      <IconComponent className="h-12 w-12 text-slate-400 mx-auto mb-4" />
+      <h3 className="text-lg font-medium text-slate-900 mb-2">{title}</h3>
+      <p className="text-slate-600 mb-6">{description}</p>
+      {actionLabel && onAction && (
+        <Button onClick={onAction}>
+          <Plus className="h-4 w-4 mr-2" />
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+
+  if (variant === "page") {
+    return (
+      <div className={cn("min-h-[50vh] flex items-center justify-center px-4", className)}>
+        {content}
+      </div>
+    );
+  }
+
+  // Default: card variant
+  return (
+    <Card className={cn("", className)}>
+      <CardContent className="py-12">
+        {content}
+      </CardContent>
+    </Card>
+  );
+}
+
+// 特定用途のプリセット
+export const NoProductsState = ({ onAddProduct }: { onAddProduct?: () => void }) => (
+  <EmptyState
+    icon="package"
+    title="商品がありません"
+    description="まだ商品が登録されていません。最初の商品を登録してみましょう。"
+    actionLabel="商品を登録"
+    onAction={onAddProduct}
+  />
+);
+
+export const NoSearchResultsState = ({ searchTerm }: { searchTerm?: string }) => (
+  <EmptyState
+    icon="search"
+    title="検索結果が見つかりません"
+    description={
+      searchTerm
+        ? `「${searchTerm}」に一致する結果が見つかりませんでした。`
+        : "条件に一致する結果が見つかりませんでした。"
+    }
+  />
+);
+
+export const NoInventoryState = () => (
+  <EmptyState
+    icon="file"
+    title="履歴がありません"
+    description="まだ入出庫の履歴がありません。商品の入出庫を記録してみましょう。"
+  />
+);

--- a/src/components/ui/error-display.tsx
+++ b/src/components/ui/error-display.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { AlertCircle, RefreshCw, ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
+
+interface ErrorDisplayProps {
+  title?: string;
+  message: string;
+  details?: string;
+  showRetry?: boolean;
+  showBack?: boolean;
+  onRetry?: () => void;
+  onBack?: () => void;
+  className?: string;
+  variant?: "card" | "alert" | "page";
+}
+
+export function ErrorDisplay({
+  title = "エラーが発生しました",
+  message,
+  details,
+  showRetry = true,
+  showBack = false,
+  onRetry,
+  onBack,
+  className,
+  variant = "card"
+}: ErrorDisplayProps) {
+  if (variant === "alert") {
+    return (
+      <Alert variant="destructive" className={cn("", className)}>
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription className="flex items-center justify-between">
+          <div>
+            <div className="font-medium">{message}</div>
+            {details && <div className="text-sm mt-1 text-muted-foreground">{details}</div>}
+          </div>
+          {showRetry && onRetry && (
+            <Button 
+              variant="outline" 
+              size="sm" 
+              onClick={onRetry}
+              className="ml-4 shrink-0"
+            >
+              <RefreshCw className="h-3 w-3 mr-1" />
+              再試行
+            </Button>
+          )}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (variant === "page") {
+    return (
+      <div className={cn("min-h-[50vh] flex items-center justify-center", className)}>
+        <Card className="max-w-md w-full mx-4">
+          <CardContent className="pt-6 text-center">
+            <AlertCircle className="h-12 w-12 text-destructive mx-auto mb-4" />
+            <h3 className="text-lg font-semibold text-slate-900 mb-2">{title}</h3>
+            <p className="text-slate-600 mb-4">{message}</p>
+            {details && (
+              <p className="text-sm text-slate-500 mb-6">{details}</p>
+            )}
+            <div className="flex gap-2 justify-center">
+              {showBack && onBack && (
+                <Button variant="outline" onClick={onBack}>
+                  <ArrowLeft className="h-4 w-4 mr-2" />
+                  戻る
+                </Button>
+              )}
+              {showRetry && onRetry && (
+                <Button onClick={onRetry}>
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  再試行
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Default: card variant
+  return (
+    <Card className={cn("", className)}>
+      <CardContent className="flex items-center justify-center py-8 text-center">
+        <div className="max-w-sm">
+          <AlertCircle className="h-8 w-8 text-destructive mx-auto mb-3" />
+          <h3 className="font-medium text-slate-900 mb-2">{title}</h3>
+          <p className="text-sm text-slate-600 mb-4">{message}</p>
+          {details && (
+            <p className="text-xs text-slate-500 mb-4">{details}</p>
+          )}
+          <div className="flex gap-2 justify-center">
+            {showBack && onBack && (
+              <Button variant="outline" size="sm" onClick={onBack}>
+                <ArrowLeft className="h-3 w-3 mr-1" />
+                戻る
+              </Button>
+            )}
+            {showRetry && onRetry && (
+              <Button size="sm" onClick={onRetry}>
+                <RefreshCw className="h-3 w-3 mr-1" />
+                再試行
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/loading-display.tsx
+++ b/src/components/ui/loading-display.tsx
@@ -77,12 +77,18 @@ export function LoadingDisplay({
 }
 
 // 便利なプリセット
-export const LoadingSpinner = ({ size = "md" }: { size?: "sm" | "md" | "lg" }) => (
+export const LoadingSpinner = ({ 
+  size = "md", 
+  className 
+}: { 
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}) => (
   <Loader2 className={cn("animate-spin", {
     "h-4 w-4": size === "sm",
     "h-6 w-6": size === "md", 
     "h-8 w-8": size === "lg"
-  })} />
+  }, className)} />
 );
 
 export const LoadingButton = ({ children, loading, ...props }: any) => (

--- a/src/components/ui/loading-display.tsx
+++ b/src/components/ui/loading-display.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface LoadingDisplayProps {
+  message?: string;
+  className?: string;
+  variant?: "card" | "inline" | "page" | "overlay";
+  size?: "sm" | "md" | "lg";
+}
+
+export function LoadingDisplay({
+  message = "読み込み中...",
+  className,
+  variant = "card",
+  size = "md"
+}: LoadingDisplayProps) {
+  const sizeClasses = {
+    sm: "h-4 w-4",
+    md: "h-6 w-6", 
+    lg: "h-8 w-8"
+  };
+
+  const textSizeClasses = {
+    sm: "text-sm",
+    md: "text-base",
+    lg: "text-lg"
+  };
+
+  if (variant === "inline") {
+    return (
+      <div className={cn("flex items-center gap-2", className)}>
+        <Loader2 className={cn("animate-spin text-slate-600", sizeClasses[size])} />
+        <span className={cn("text-slate-600", textSizeClasses[size])}>{message}</span>
+      </div>
+    );
+  }
+
+  if (variant === "overlay") {
+    return (
+      <div className={cn(
+        "absolute inset-0 bg-white/80 backdrop-blur-sm flex items-center justify-center z-50",
+        className
+      )}>
+        <div className="text-center">
+          <Loader2 className={cn("animate-spin text-slate-600 mx-auto mb-2", sizeClasses[size])} />
+          <p className={cn("text-slate-600", textSizeClasses[size])}>{message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === "page") {
+    return (
+      <div className={cn("min-h-[50vh] flex items-center justify-center", className)}>
+        <div className="text-center">
+          <Loader2 className="h-12 w-12 animate-spin text-slate-600 mx-auto mb-4" />
+          <p className="text-lg text-slate-600">{message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Default: card variant
+  return (
+    <Card className={cn("", className)}>
+      <CardContent className="flex items-center justify-center py-8">
+        <div className="text-center">
+          <Loader2 className={cn("animate-spin text-slate-600 mx-auto mb-3", sizeClasses[size])} />
+          <p className={cn("text-slate-600", textSizeClasses[size])}>{message}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// 便利なプリセット
+export const LoadingSpinner = ({ size = "md" }: { size?: "sm" | "md" | "lg" }) => (
+  <Loader2 className={cn("animate-spin", {
+    "h-4 w-4": size === "sm",
+    "h-6 w-6": size === "md", 
+    "h-8 w-8": size === "lg"
+  })} />
+);
+
+export const LoadingButton = ({ children, loading, ...props }: any) => (
+  <button disabled={loading} {...props}>
+    {loading && <LoadingSpinner size="sm" className="mr-2" />}
+    {children}
+  </button>
+);

--- a/src/components/ui/responsive-grid.tsx
+++ b/src/components/ui/responsive-grid.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface ResponsiveGridProps {
+  children: React.ReactNode;
+  cols?: {
+    default?: number;
+    sm?: number;
+    md?: number;
+    lg?: number;
+    xl?: number;
+  };
+  gap?: number;
+  className?: string;
+}
+
+export function ResponsiveGrid({
+  children,
+  cols = {
+    default: 1,
+    sm: 1,
+    md: 2,
+    lg: 3,
+    xl: 4
+  },
+  gap = 6,
+  className
+}: ResponsiveGridProps) {
+  const gridClasses = cn(
+    "grid",
+    {
+      [`grid-cols-${cols.default}`]: cols.default,
+      [`sm:grid-cols-${cols.sm}`]: cols.sm,
+      [`md:grid-cols-${cols.md}`]: cols.md,
+      [`lg:grid-cols-${cols.lg}`]: cols.lg,
+      [`xl:grid-cols-${cols.xl}`]: cols.xl,
+      [`gap-${gap}`]: gap
+    },
+    className
+  );
+
+  return <div className={gridClasses}>{children}</div>;
+}
+
+// プリセットグリッド
+export const StatsGrid = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <ResponsiveGrid
+    cols={{
+      default: 1,
+      sm: 2,
+      lg: 4
+    }}
+    gap={6}
+    className={className}
+  >
+    {children}
+  </ResponsiveGrid>
+);
+
+export const ProductGrid = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <ResponsiveGrid
+    cols={{
+      default: 1,
+      md: 2,
+      lg: 3,
+      xl: 4
+    }}
+    gap={6}
+    className={className}
+  >
+    {children}
+  </ResponsiveGrid>
+);
+
+export const FormGrid = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <ResponsiveGrid
+    cols={{
+      default: 1,
+      md: 2
+    }}
+    gap={6}
+    className={className}
+  >
+    {children}
+  </ResponsiveGrid>
+);


### PR DESCRIPTION
## Summary
- 統一されたエラーハンドリングとローディング表示
- レスポンシブ対応の大幅改善
- Empty State（データなし状態）の統一
- ユーザー体験の向上

## 主要改善

### 🎯 統一UIコンポーネント
- **ErrorDisplay**: 3つのvariant（alert/card/page）で統一されたエラー表示
- **LoadingDisplay**: 4つのvariant（inline/overlay/card/page）でローディング状態統一
- **EmptyState**: データなし状態の統一表示とアクションボタン
- **ResponsiveGrid**: レスポンシブグリッドヘルパーコンポーネント

### 🔄 全コンポーネント改善
#### Dashboard
- 統一LoadingDisplay/ErrorDisplayに移行
- StatsGridでレスポンシブ統一（1→2→4カラム）
- エラー時の再試行機能付き

#### Products
- NoProductsState追加（新規登録ボタン付き）
- LoadingDisplay/ErrorDisplay統一
- フォームボタンにローディングスピナー追加

#### Inventory  
- NoInventoryState追加
- DataTableにEmpty State対応
- 統一されたローディング表示

### 📱 レスポンシブ改善
- **StatsGrid**: モバイル1→タブレット2→デスクトップ4カラム
- **ProductGrid**: 1→2→3→4カラムの段階的レスポンシブ
- **FormGrid**: 1→2カラムのフォームレイアウト
- モバイルファーストアプローチの徹底

### 🎨 UX向上
- **一貫したエラー体験**: 全画面で統一されたエラー表示
- **リトライ機能**: エラー時の簡単な再試行
- **ローディング改善**: 視覚的フィードバックの向上
- **Empty State**: ユーザーへの適切なガイダンス

## 技術実装

### 新規コンポーネント
```typescript
// エラー表示の統一
<ErrorDisplay 
  variant="page" 
  message="データの取得に失敗しました"
  onRetry={handleRetry}
/>

// ローディング表示の統一  
<LoadingDisplay 
  variant="card"
  message="データを読み込み中..."
/>

// Empty State
<NoProductsState 
  onAddProduct={() => router.push('/products/new')}
/>
```

### レスポンシブグリッド
```typescript
<StatsGrid>
  <StatCard />
  <StatCard />
  <StatCard />
  <StatCard />
</StatsGrid>
```

## Before/After

### Before
- 各コンポーネントで独自のローディング/エラー表示
- レスポンシブ対応が不統一
- Empty Stateなし

### After
- 統一されたUI/UXパターン
- 一貫したレスポンシブ体験
- 適切なEmpty State表示

## Test plan
- [x] 全画面でのローディング表示確認
- [x] エラー状態の表示と再試行機能確認
- [x] Empty State表示確認
- [x] レスポンシブデザイン確認（モバイル/タブレット/デスクトップ）
- [x] フォーム送信時のローディング確認

🤖 Generated with [Claude Code](https://claude.ai/code)